### PR TITLE
DM-33076: Only support TCP/IP connections.

### DIFF
--- a/python/lsst/ts/ess/labjack/labjack_data_client.py
+++ b/python/lsst/ts/ess/labjack/labjack_data_client.py
@@ -47,8 +47,11 @@ CONNECT_TIMEOUT = 5
 # and reading telemetry (seconds)
 READ_TIMEOUT = 5
 
-# LabJack's special identifier to run in simulation mode.
-MOCK_IDENTIFIER = "LJM_DEMO_MODE"
+# LabJack's connection type for TCP/IP
+CONNECTION_TYPE = "TCP"
+
+# LabJack's special "identifier" to run in simulation mode
+MOCK_HOST = "LJM_DEMO_MODE"
 
 
 class LabJackDataClient(common.BaseDataClient):
@@ -115,16 +118,8 @@ properties:
     description: LabJack model
     type: string
     default: T7
-  connection_type:
-    description: Connection type
-    type: string
-    default: TCP
-  identifier:
-    description: >-
-        LabJack indentifier:
-        * An IP address if connection_type=TCP
-        * A serial number if connection_type = USB
-        * For testing in an environment with only one LabJack you may use ANY.
+  host:
+    description: IP address of LabJack
   poll_interval:
     description: Polling interval (seconds)
     type: number
@@ -181,8 +176,7 @@ properties:
       additionalProperties: false
 required:
   - device_type
-  - connection_type
-  - identifier
+  - host
   - poll_interval
   - topics
 additionalProperties: false
@@ -231,7 +225,7 @@ additionalProperties: false
         self.channel_names = tuple(sorted(channel_names))
 
     def descr(self) -> str:
-        return f"identifier={self.config.identifier}"
+        return f"host={self.config.host}"
 
     async def run_in_thread(self, func: Callable[[], Any], timeout: float) -> Any:
         """Run a blocking function in a thread pool executor.
@@ -298,13 +292,11 @@ additionalProperties: false
             self._blocking_disconnect()
 
         if self.simulation_mode == 0:
-            identifier = self.config.identifier
+            host = self.config.host
         else:
-            identifier = MOCK_IDENTIFIER
+            host = MOCK_HOST
 
-        self.handle = ljm.openS(
-            self.config.device_type, self.config.connection_type, identifier
-        )
+        self.handle = ljm.openS(self.config.device_type, CONNECTION_TYPE, host)
         self._blocking_read()
 
     def _blocking_disconnect(self) -> None:

--- a/tests/data/bad_empty_channel_names.yaml
+++ b/tests/data/bad_empty_channel_names.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/data/bad_invalid_channel_names.yaml
+++ b/tests/data/bad_invalid_channel_names.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/data/bad_missing_channel_names.yaml
+++ b/tests/data/bad_missing_channel_names.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/data/bad_no_field_name.yaml
+++ b/tests/data/bad_no_field_name.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/data/bad_no_location.yaml
+++ b/tests/data/bad_no_location.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/data/bad_no_sensor_name.yaml
+++ b/tests/data/bad_no_sensor_name.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     field_name: temperature

--- a/tests/data/bad_no_topic_name.yaml
+++ b/tests/data/bad_no_topic_name.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - sensor_name: labjack_test_1
     field_name: temperature

--- a/tests/data/good_full.yaml
+++ b/tests/data/good_full.yaml
@@ -1,6 +1,5 @@
 device_type: T4
-connection_type: USB
-identifier: test.foo.bar
+host: test.foo.bar
 poll_interval: 0.2
 topics: 
   - topic_name: tel_temperature

--- a/tests/data/good_minimal.yaml
+++ b/tests/data/good_minimal.yaml
@@ -1,4 +1,4 @@
-identifier: test.foo.bar
+host: test.foo.bar
 topics: 
   - topic_name: tel_temperature
     sensor_name: labjack_test_1

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -53,7 +53,6 @@ class DataClientTestCase(unittest.IsolatedAsyncioTestCase):
 
         # Check against the values in file good_full.yaml
         assert config.device_type == "T4"
-        assert config.connection_type == "USB"
         assert config.poll_interval == 0.2
         assert len(config.topics) == 3
         topics = [types.SimpleNamespace(**topic_dict) for topic_dict in config.topics]
@@ -86,7 +85,6 @@ class DataClientTestCase(unittest.IsolatedAsyncioTestCase):
 
         # Check against the values in file good_minimal.yaml
         assert config.device_type == "T7"
-        assert config.connection_type == "TCP"
         assert config.poll_interval == 1
         assert len(config.topics) == 1
         topics = [types.SimpleNamespace(**topic_dict) for topic_dict in config.topics]


### PR DESCRIPTION
Simplify the configuration by removing connection_type.
Rename identifier to host.